### PR TITLE
rpi: set KERNEL_DEVICETREE at layer level, bbappend not working

### DIFF
--- a/meta-raspberrypi-fs/conf/layer.conf
+++ b/meta-raspberrypi-fs/conf/layer.conf
@@ -10,3 +10,5 @@ BBFILE_PATTERN_raspberrypi-fs = "^${LAYERDIR}/"
 BBFILE_PRIORITY_raspberrypi-fs = "8"
 
 LAYERDEPENDS_raspberrypi-fs = "raspberrypi"
+
+KERNEL_DEVICETREE_append = "${@bb.utils.contains("MACHINE_FEATURES", "can", " overlays/mcp2515-can0-overlay.dtb", "", d)}"

--- a/meta-raspberrypi-fs/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/meta-raspberrypi-fs/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,1 +1,0 @@
-KERNEL_DEVICETREE_append = "${@bb.utils.contains("MACHINE_FEATURES", "can", " overlays/mcp2515-can0-overlay.dtb", "", d)}"


### PR DESCRIPTION
It seems not possible to set (append) KERNEL_DEVICETREE variable in
linux-raspberrypi_%.bbappend due to usage of anonymous python function
which set this variable in linux-raspberrypi.inc [1].

Set it at layer level as done by others [2].

1 - http://git.yoctoproject.org/cgit.cgi/meta-raspberrypi/tree/recipes-kernel/linux/linux-raspberrypi.inc?h=krogoth#n34
2 - https://github.com/resin-os/resin-raspberrypi/commit/6265dc109abb5e7936a4ab0a9a15a5b734aa5130

Signed-off-by: Jeremy Rocher <rocher.jeremy@gmail.com>